### PR TITLE
add nsenter flag --all

### DIFF
--- a/nsenter.go
+++ b/nsenter.go
@@ -11,6 +11,7 @@ import (
 // Config is the nsenter configuration used to generate
 // nsenter command
 type Config struct {
+	AllNamespaces       bool   // Enter all namespaces of the target process
 	Cgroup              bool   // Enter cgroup namespace
 	CgroupFile          string // Cgroup namespace location, default to /proc/PID/ns/cgroup
 	FollowContext       bool   // Set SELinux security context
@@ -71,6 +72,10 @@ func (c *Config) buildCommand(ctx context.Context) (*exec.Cmd, error) {
 
 	var args []string
 	args = append(args, "--target", strconv.Itoa(c.Target))
+
+	if c.AllNamespaces {
+		args = append(args, "--all")
+	}
 
 	if c.Cgroup {
 		if c.CgroupFile != "" {


### PR DESCRIPTION
nsenter man:
 -a, --all
Enter all namespaces of the target process by the default /proc/[pid]/ns/* namespace paths. The default paths to the target process namespaces may be overwritten by namespace specific options (e.g. --all --mount=[path]). The user namespace will be ignored if the same as the caller's current user namespace. It prevents a caller that has dropped capabilities from regaining those capabilities via a call to setns().  See setns(2) for more details.